### PR TITLE
Preparing Tupl for publishing in the nexus maven repository

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+This file intended to be used byi Tupl developers.
+
+# How to release
+
+Prerequisite: install gpg.
+
+Then do:
+
+```
+mvn release:clean release:prepare -P release 
+```
+
+After this step maven will ask you for the next version, compile sources, build jar, sources jar and javadoc jar.
+
+If something goes wrong this step can easily be reverted by doing ``git reset HEAD --hard`` and then (optionally) ``git clean -f -d`` which will return repository to its initial state.
+
+Once ``release:prepare`` finishes, the artifacts can be published in nexus repository by running
+
+```
+mvn release:perform -P release
+```
+

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,13 @@
   <artifactId>tupl</artifactId>
   <packaging>jar</packaging>
   <name>Tupl</name>
-  <version>1.2</version>
+  <version>1.2.0-SNAPSHOT</version>
   <description>
     The Unnamed Persistence Library.
   </description>
+
   <url>https://github.com/cojen/Tupl</url>
+
   <inceptionYear>2011</inceptionYear>
 
   <organization>
@@ -21,8 +23,50 @@
     <license>
       <name>Apache License Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <developers>
+    <developer>
+      <id>broneill</id>
+      <name>Brian O'Neill</name>
+      <email>place@your.email</email>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git@github.com:cojen/Tupl.git</connection>
+    <developerConnection>scm:git:git@github.com:cojen/Tupl.git</developerConnection>
+    <url>git@github.com:cojen/Tupl.git</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+  <issueManagement>
+    <url>https://github.com/cojen/Tupl/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <properties>
+    <!--  compiler settings -->
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+
+    <!-- encoding -->
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -33,33 +77,94 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
+  <profiles>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
-          <configuration>
-            <javadocVersion>1.7</javadocVersion>
-            <detectJavaApiLink>true</detectJavaApiLink>
-            <links>
-              <link>http://docs.oracle.com/javase/7/docs/api</link>
-            </links>
-            <notimestamp>true</notimestamp>
-          </configuration>
-      </plugin>
+    <!-- This profile SHOULD be activated when making release -->
+    <profile>
+      <id>release</id>
 
-    </plugins>
-  </build>
+      <build>
+        <plugins>
+          <!-- Staging plugin - http://central.sonatype.org/pages/apache-maven.html -->
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.2</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+
+          <!-- Release plugin -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>2.5</version>
+            <configuration>
+              <autoVersionSubmodules>true</autoVersionSubmodules>
+              <useReleaseProfile>false</useReleaseProfile>
+              <releaseProfiles>release</releaseProfiles>
+              <goals>deploy</goals>
+            </configuration>
+          </plugin>
+
+          <!-- Encryption plugin for deploying release artifacts -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Generate sources and javadoc -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <javadocVersion>1.7</javadocVersion>
+              <detectJavaApiLink>true</detectJavaApiLink>
+              <links>
+                <link>http://docs.oracle.com/javase/7/docs/api</link>
+              </links>
+              <notimestamp>true</notimestamp>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
This prepares Tupl for publishing in the nexus maven repository.

Note, that you should have a valid gpg key for signing your artifacts (of course you also need to install gpg2 on the computer you're going to use to release artifacts). After installing a key your ``~/.gnupg`` directory may look as follows:

```
$ ls ~/.gnupg/
gpg.conf	pubring.gpg	secring.gpg	trustdb.gpg
```

Also you need to modify your ``~/.m2/settings.xml`` a bit. This is important as it tells release plugin that you're going to release this to ``ossrh`` repository (note, that ossrh is also referenced in ``pom.xml``).

This is how it can look like (I'm copying mine with asterisks instead of passwords):

```xml
<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
  http://maven.apache.org/xsd/settings-1.0.0.xsd">

  <!--
      See http://central.sonatype.org/pages/apache-maven.html and 
      http://maven.apache.org/guides/mini/guide-encryption.html and
      https://maven.apache.org/settings.html
  -->

  <servers>
    <server>
      <id>ossrh</id>
      <username>YOUR_USERNAME</username>
      <password>*</password>
    </server>
  </servers>

  <profiles>
    <profile>
      <id>ossrh</id>
      <activation>
        <activeByDefault>true</activeByDefault>
      </activation>
      <properties>
        <gpg.executable>gpg2</gpg.executable>
        <gpg.passphrase>*</gpg.passphrase>
      </properties>
    </profile>
  </profiles>
</settings>
```

You don't need to have gpg2 installed for any non-release work. The signing step (as well as attaching sources and generating javadoc) is performed only when 'release' profile is activated.

Feel free to ask if you have any questions related to maven.